### PR TITLE
upgrade email mime handling for multipart

### DIFF
--- a/content-copy-tool/contentcopytool/lib/makemultipart.py
+++ b/content-copy-tool/contentcopytool/lib/makemultipart.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 import os
 import argparse
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEBase import MIMEBase
-from email import Encoders
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email import encoders
 
 def makemultipart(atomfile, package, outfile):
     atompart = MIMEBase('application', 'atom+xml')
@@ -15,7 +15,7 @@ def makemultipart(atomfile, package, outfile):
         'attachment; name=payload; filename=%s' % os.path.basename(
             package.name))
     payloadpart.set_payload(package.read())
-    Encoders.encode_base64(payloadpart)
+    encoders.encode_base64(payloadpart)
 
     message = MIMEMultipart('related')
     message.attach(atompart)


### PR DESCRIPTION
upgrade to latest email packages because here are deprecated versions used (python >2.6):
https://docs.python.org/2/library/email.html#package-history

this PR is needed for later for Python 3 compatibility: https://github.com/openstax/cnx-tools/pull/10

Tested with Python 2 and works.