### PR TITLE
add two level verbose DEBUG levels for console output and in cli options

### DIFF
--- a/content-copy-tool/README.md
+++ b/content-copy-tool/README.md
@@ -231,6 +231,8 @@ your options:
 --dry-run
     Parses the input file data and steps through the other options without
     creating/copying/altering/publishing any content.
+--verbose
+    Verbose DEBUG messages in console. Developers of this tool are encouraged to use the even more verbose DEBUG level -vv .
 ```
 Until now, the tool has been operating on every entry in the input file. But
 sometimes the input file has an entire book’s worth of data and you only want to

--- a/content-copy-tool/contentcopytool/content_copy.py
+++ b/content-copy-tool/contentcopytool/content_copy.py
@@ -45,8 +45,9 @@ def run(settings, input_file, run_options):
         sys.exit(1)
 
     logfile = config['logfile']
-    logger = util.init_logger(logfile)
+    logger = util.init_logger(logfile, run_options.verboselevel)
     logger.debug("Logger is up and running.")
+    logger.debugv("Verbose DEBUGV level for developers is activated.")
 
     # Bookmap
     bookmap_config = bkmap.BookmapConfiguration(str(config['chapter_number_column']),
@@ -410,7 +411,7 @@ def main():
         args.chapters.sort()
     run_options = op.RunOptions(args.modules, args.workgroups, args.copy, args.roles, args.collection,
                                 args.units, args.publish, args.publish_collection, args.chapters, args.exclude,
-                                args.dryrun)
+                                args.dryrun, args.verboselevel)
     booktitle = ""
     signal.signal(signal.SIGINT, util.handle_terminate)
     signal.signal(signal.SIGTSTP, util.handle_user_skip)

--- a/content-copy-tool/contentcopytool/lib/command_line_interface.py
+++ b/content-copy-tool/contentcopytool/lib/command_line_interface.py
@@ -82,6 +82,8 @@ def get_parser(version):
     control_args.add_argument("--dry-run", action="store_true", dest="dryrun",
                               help="Steps through input processing, but does NOT create or copy any content. "
                                    "This is used for checking input file correctness (optional).")
+    control_args.add_argument("-v", "--verbose", action="count", dest="verboselevel", default=0,
+                              help="Verbose DEBUG messages in console. Developers of this tool are encouraged to use the even more verbose DEBUG level -vv .")
 
     parser.add_argument("--version", action="version", version=version, help="Prints the tool's version")
 

--- a/content-copy-tool/contentcopytool/lib/operation_objects.py
+++ b/content-copy-tool/contentcopytool/lib/operation_objects.py
@@ -25,7 +25,8 @@ class CopyConfiguration:
 class RunOptions:
     """ The input options that describe what the tool will do. """
     def __init__(self, modules, workgroups, copy, roles, collections, units,
-                 publish, publish_collection, chapters, exclude, dryrun):
+                 publish, publish_collection, chapters, exclude, dryrun,
+                 verboselevel):
         self.modules = modules
         self.workgroups = workgroups
         if self.workgroups:
@@ -39,6 +40,7 @@ class RunOptions:
         self.chapters = chapters
         self.exclude = exclude
         self.dryrun = dryrun
+        self.verboselevel = verboselevel
 
 
 # Operation Objects

--- a/content-copy-tool/contentcopytool/lib/util.py
+++ b/content-copy-tool/contentcopytool/lib/util.py
@@ -7,12 +7,24 @@ This file contains some basic utility functions for the content-copy-tool.
 Functions relate to tool setup, selenium, and I/O.
 """
 
-def init_logger(filename):
+# add a new more verbose debug level
+DEBUG_LEVELV_NUM = 9
+
+def init_logger(filename, verbose=0):
     """
     Initializes and returns a basic logger to the specified filename.
     """
+
+    # add a new debugv level
+    logging.addLevelName(DEBUG_LEVELV_NUM, "DEBUGV")
+    def debugv(self, message, *args, **kws):
+        if self.isEnabledFor(DEBUG_LEVELV_NUM):
+            # Yes, logger takes its '*args' as 'args'.
+            self._log(DEBUG_LEVELV_NUM, message, args, **kws)
+    logging.Logger.debugv = debugv
+
     logger = logging.getLogger('content-copy')
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(DEBUG_LEVELV_NUM)
     console_handler = logging.StreamHandler()
     file_handler = logging.FileHandler(filename)
 
@@ -22,7 +34,13 @@ def init_logger(filename):
     console_handler.setFormatter(console_formatter)
     file_handler.setFormatter(file_formatter)
 
-    console_handler.setLevel(logging.INFO)
+    console_debug_level = logging.INFO
+    if (verbose==1):
+        console_debug_level = logging.DEBUG
+    elif (verbose>=2):
+        console_debug_level = DEBUG_LEVELV_NUM
+
+    console_handler.setLevel(console_debug_level)
     file_handler.setLevel(logging.DEBUG)
 
     logger.addHandler(console_handler)


### PR DESCRIPTION
Add options for verbose DEBUG output logs in command line.

* add options for printing out DEBUG messages in command line.
* add an even more verbose DEBUGV level (9) for internal development purposes (Python 3).