### PR TITLE
Fix collection creation redirect bug

### DIFF
--- a/content-copy-tool/contentcopytool/lib/http_util.py
+++ b/content-copy-tool/contentcopytool/lib/http_util.py
@@ -41,7 +41,7 @@ def http_post_request(url, headers={}, auth=(), data={}):
         return requests.post(response.headers['Location'], headers=headers, auth=auth, data=data, allow_redirects=False)
 
     def follow_with_get(response):
-        return requests.Session().send(response.next, allow_redirects=False)
+        return requests.get(response.headers['Location'], headers=headers, auth=auth, data=data, allow_redirects=False)
 
     signal.signal(signal.SIGALRM, handle_timeout)
     signal.alarm(timeout)


### PR DESCRIPTION
Error reported by ryan: `AttributeError: 'Response' object has no attribute 'next'`
I don't know why this works. I wrote this a long time ago and I think the original line may have just been to save space/time. Maybe it's an issue with how requests stores it's redirect location. But it now works, which is cool. It's the content-copy-tool, so I'm not going to worry about it too much.